### PR TITLE
Sun33t/sun 88 add recaptcha to contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To run this project, you will need to add the following environment variables to
 
 `NEXT_PUBLIC_SANITY_GRAPHQL_URL`
 
+`NEXT_PUBLIC_TURNSTILE_SITE_KEY`
+
 `SANITY_API_READ_TOKEN`
 
 `RESEND_API_KEY`
@@ -27,6 +29,8 @@ To run this project, you will need to add the following environment variables to
 `RESEND_SEND_TO_EMAIL`
 
 `RESEND_AUDIENCE_ID`
+
+`TURNSTILE_SECRET_KEY`
 
 ## Run Locally
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -4,10 +4,12 @@ declare namespace NodeJS {
     NEXT_PUBLIC_SANITY_PROJECT_ID?: string
     NEXT_PUBLIC_SANITY_DATASET?: string
     NEXT_PUBLIC_SANITY_API_VERSION?: string
+    NEXT_PUBLIC_TURNSTILE_SITE_KEY?: string
     SANITY_API_READ_TOKEN?: string
     RESEND_API_KEY?: string
     RESEND_SEND_FROM_EMAIL?: string
     RESEND_SEND_TO_EMAIL?: string
     RESEND_AUDIENCE_ID?: string
+    TURNSTILE_SECRET_KEY?: string
   }
 }

--- a/lib/turnstile.ts
+++ b/lib/turnstile.ts
@@ -1,0 +1,40 @@
+import { validateTurnstileToken } from 'next-turnstile'
+import assertValue from './assertValue'
+
+const turnstileSecretKey = assertValue(
+  process.env.TURNSTILE_SECRET_KEY,
+  'Missing environment variable: TURNSTILE_SECRET_KEY'
+)
+
+export const validateTurnstile = async ({
+  token,
+  sandbox
+}: {
+  token: string | null
+  sandbox?: boolean
+}) => {
+  if (!token || typeof token !== 'string') {
+    console.error('No turnstile token provided')
+    return { success: false, message: 'Cloudflare Turnstile token missing' }
+  }
+
+  const turnstileResponse = await validateTurnstileToken({
+    token,
+    secretKey: turnstileSecretKey,
+    sandbox
+  })
+
+  if (!turnstileResponse.success) {
+    console.error('Turnstile submission error: ', turnstileResponse.error_codes)
+
+    return {
+      success: false,
+      message: 'Turnstile validation failed.'
+    }
+  }
+
+  return {
+    message: 'Turnstile token validated successfully.',
+    success: true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "framer-motion": "^10.18.0",
         "next": "^14.1.4",
         "next-sanity": "^8.5.0",
+        "next-turnstile": "^1.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-email": "^2.1.4",
@@ -13326,6 +13327,17 @@
         "svelte": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-turnstile": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/next-turnstile/-/next-turnstile-1.0.5.tgz",
+      "integrity": "sha512-DUdmQ0m4lSkHD2nn/Nmh8nAKjYlZD9nXJTaQJJAr0pYE0MUHmwz8bvjex71RuVJaoGRsP7qGnlhuEnXDEuojcw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": ">=12",
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "framer-motion": "^10.18.0",
     "next": "^14.1.4",
     "next-sanity": "^8.5.0",
+    "next-turnstile": "^1.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-email": "^2.1.4",


### PR DESCRIPTION
This pull request introduces Cloudflare Turnstile for bot protection in the contact form. It includes updates to handle Turnstile tokens, validate them, and ensure the form submission is gated by successful validation. The changes span environment variable updates, form logic adjustments, and the addition of a new utility function for token validation.

### Integration of Cloudflare Turnstile:

* **Environment Variables:**
  - Added `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` to the required environment variables in `README.md` for configuring Turnstile. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R34)

* **Token Validation Logic:**
  - Introduced a new utility function `validateTurnstile` in `lib/turnstile.ts` to validate Turnstile tokens using the secret key and handle errors.

* **Contact Form Updates:**
  - Updated `ContactForm.tsx` to include a Turnstile widget, manage the token state, and disable the submit button if the token is invalid. [[1]](diffhunk://#diff-b194f05d40e20775e80b69233f8339a8f3712b30fd1081a93da34a3892b9669dR4-R14) [[2]](diffhunk://#diff-b194f05d40e20775e80b69233f8339a8f3712b30fd1081a93da34a3892b9669dL16-R36) [[3]](diffhunk://#diff-b194f05d40e20775e80b69233f8339a8f3712b30fd1081a93da34a3892b9669dR46-R54) [[4]](diffhunk://#diff-b194f05d40e20775e80b69233f8339a8f3712b30fd1081a93da34a3892b9669dL97-R124)
  - Integrated the Turnstile token validation into the `createContactRequest` function in `app/actions.tsx` to ensure submissions are verified.

### Dependency Addition:

* Added `next-turnstile` package to `package.json` to support the Turnstile integration.